### PR TITLE
Added applying AddStyle from lh-dev to GOTOIMPL

### DIFF
--- a/autoload/lh/cpp/GotoFunctionImpl.vim
+++ b/autoload/lh/cpp/GotoFunctionImpl.vim
@@ -452,8 +452,10 @@ function! s:BuildFunctionSignature4impl(proto,className)
         \ . '('.implParamsStr . ')'
         \ . (proto.const ? ' const' : '')
         \ . (!empty(proto.throw) ? ' throw ('.join(proto.throw, ',').')' : '')
-        \ . "\n{\n}"
-  return res
+        \ . "{\n}"
+  let styles = lh#dev#style#get(&ft)
+  if empty(styles) | return res | endif
+  return lh#dev#style#apply(res)
   "}}}4
 endfunction
 "------------------------------------------------------------------------

--- a/autoload/lh/cpp/GotoFunctionImpl.vim
+++ b/autoload/lh/cpp/GotoFunctionImpl.vim
@@ -445,17 +445,23 @@ function! s:BuildFunctionSignature4impl(proto,className)
   " 5- Return{{{4
   " TODO: some styles like to put return types and function names on two
   " different lines
-  let res = comments
+  let unstyled = comments
         \ . return . ' '
         \ . className
         \ . join(proto.name, '::')
         \ . '('.implParamsStr . ')'
         \ . (proto.const ? ' const' : '')
         \ . (!empty(proto.throw) ? ' throw ('.join(proto.throw, ',').')' : '')
-        \ . "{\n}"
+        \ . "{}"
   let styles = lh#dev#style#get(&ft)
-  if empty(styles) | return res | endif
-  return lh#dev#style#apply(res)
+  let styled = lh#dev#style#apply(unstyled)
+
+  let res = unstyled
+  if !empty(styles)
+    let res = styled
+  endif
+
+  return res
   "}}}4
 endfunction
 "------------------------------------------------------------------------


### PR DESCRIPTION
Pretty new to VimL so this might be unnecessary but the documentation states that that g:c_nl_before_curlyB is deprecated yet I didn't manage to apply AddStyle to GOTOIMPL no matter what I tried.
I copied the apply style code from mu-template to the end of s:BuildFunctionSignature4impl function and it seems to work for me now.